### PR TITLE
Split CI and release pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Artifact
+name: Release
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 jobs:
-  release-artifact:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -50,7 +50,7 @@ jobs:
           name: ${{ steps.release_version.outputs.artifact_name }}-archive
           path: artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz
 
-      - name: Attach archive to tagged GitHub release
+      - name: Create or update GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Current local commands:
 - `npm run release:artifact`
 - `npm run release:verify`
 
+Current pipelines:
+- `CI`
+  - runs on pushes to `main` and on pull requests
+  - installs dependencies and runs `npm test`
+- `Release`
+  - runs on version tags like `v0.1.0` or by manual dispatch
+  - runs tests, verifies the artifact, uploads the packaged files, and creates or updates the tagged GitHub release
+
 Current shipped artifact contents are documented in:
 - `docs/release-artifact.md`
 


### PR DESCRIPTION
## Summary
- split the starter repo automation into separate CI and Release workflows
- keep the release pipeline responsible for packaging and creating tagged GitHub releases
- update the README so the pipeline behavior is easy to understand

## Verification
- npm test
- npm run release:verify