### PR TITLE
Stage core package in starter workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,45 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
 
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+
+      - name: Read core package version
+        id: core_version
+        run: |
+          CORE_VERSION=$(node -p "require('./package.json').dependencies['@service-lasso/service-lasso'].replace(/^[^0-9]*/, '')")
+          echo "core_version=$CORE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check out core repo
+        uses: actions/checkout@v4
+        with:
+          repository: service-lasso/service-lasso
+          ref: v${{ steps.core_version.outputs.core_version }}
+          path: .service-lasso-core
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-          registry-url: https://npm.pkg.github.com
-          scope: "@service-lasso"
+          cache-dependency-path: |
+            package-lock.json
+            .service-lasso-core/package-lock.json
 
-      - name: Install dependencies
-        run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+      - name: Install core build dependencies
+        run: npm ci
+        working-directory: .service-lasso-core
+
+      - name: Stage core package
+        run: npm run package:stage
+        working-directory: .service-lasso-core
+
+      - name: Install starter dependencies
+        run: >
+          npm install --package-lock=false --no-save
+          .service-lasso-core/artifacts/npm/service-lasso-package-${{ steps.core_version.outputs.core_version }}/service-lasso-service-lasso-${{ steps.core_version.outputs.core_version }}.tgz
 
       - name: Run tests
         run: npm test
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,34 +13,51 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: read
 
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+
+      - name: Read core package version
+        id: core_version
+        run: |
+          CORE_VERSION=$(node -p "require('./package.json').dependencies['@service-lasso/service-lasso'].replace(/^[^0-9]*/, '')")
+          echo "core_version=$CORE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check out core repo
+        uses: actions/checkout@v4
+        with:
+          repository: service-lasso/service-lasso
+          ref: v${{ steps.core_version.outputs.core_version }}
+          path: .service-lasso-core
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-          registry-url: https://npm.pkg.github.com
-          scope: "@service-lasso"
+          cache-dependency-path: |
+            package-lock.json
+            .service-lasso-core/package-lock.json
 
-      - name: Install dependencies
-        run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+      - name: Install core build dependencies
+        run: npm ci
+        working-directory: .service-lasso-core
+
+      - name: Stage core package
+        run: npm run package:stage
+        working-directory: .service-lasso-core
+
+      - name: Install starter dependencies
+        run: >
+          npm install --package-lock=false --no-save
+          .service-lasso-core/artifacts/npm/service-lasso-package-${{ steps.core_version.outputs.core_version }}/service-lasso-service-lasso-${{ steps.core_version.outputs.core_version }}.tgz
 
       - name: Run tests
         run: npm test
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Verify release artifact
         run: npm run release:verify
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Read release version
         id: release_version


### PR DESCRIPTION
## Summary
- stage the matching core package from the service-lasso repo inside CI and release workflows
- stop depending on GitHub Packages read access in starter pipelines
- keep starter artifact verification on free loopback ports

## Verification
- npm test
- npm run release:verify