### PR TITLE
Apply artifact-mode parity to app-tauri

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
 
 jobs:
   release:
@@ -18,6 +16,16 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v5
+
+      - name: Compute release version
+        id: release_version
+        shell: bash
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          version="$(date -u +%Y.%-m.%-d)-${short_sha}"
+          name="$(node -p "require('./package.json').name.split('/').pop()")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "artifact_base=${name}-${version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node
         uses: actions/setup-node@v5
@@ -36,36 +44,52 @@ jobs:
         run: npm run release:verify
         env:
           NODE_AUTH_TOKEN: ${{ github.token }}
+          SERVICE_LASSO_RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
 
-      - name: Read release version
-        id: release_version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          NAME=$(node -p "require('./package.json').name.split('/').pop()")
-          echo "artifact_name=$NAME-$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Upload staged artifact folder
+      - name: Upload staged source artifact folder
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ steps.release_version.outputs.artifact_name }}
-          path: artifacts/${{ steps.release_version.outputs.artifact_name }}
+          name: ${{ steps.release_version.outputs.artifact_base }}-source
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-source
 
-      - name: Upload packaged archive
+      - name: Upload staged runtime artifact folder
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ steps.release_version.outputs.artifact_name }}-archive
-          path: artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz
+          name: ${{ steps.release_version.outputs.artifact_base }}-runtime
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-runtime
+
+      - name: Upload staged preloaded artifact folder
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.release_version.outputs.artifact_base }}-preloaded
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-preloaded
+
+      - name: Upload packaged source archive
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.release_version.outputs.artifact_base }}-source-archive
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-source.tar.gz
+
+      - name: Upload packaged runtime archive
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.release_version.outputs.artifact_base }}-runtime-archive
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-runtime.tar.gz
+
+      - name: Upload packaged preloaded archive
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.release_version.outputs.artifact_base }}-preloaded-archive
+          path: artifacts/${{ steps.release_version.outputs.artifact_base }}-preloaded.tar.gz
 
       - name: Create or update GitHub release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SERVICE_LASSO_RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
         run: |
-          TAG_NAME="${GITHUB_REF_NAME}"
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            TAG_NAME="latest"
-            git tag -f "$TAG_NAME" "$GITHUB_SHA"
-            git push origin "refs/tags/$TAG_NAME" --force
-          fi
-          ARCHIVE_PATH="artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz"
-          gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Starter-template source artifact release."
-          gh release upload "$TAG_NAME" "$ARCHIVE_PATH" --clobber
+          TAG_NAME="${SERVICE_LASSO_RELEASE_VERSION}"
+          SOURCE_ARCHIVE="artifacts/${{ steps.release_version.outputs.artifact_base }}-source.tar.gz"
+          RUNTIME_ARCHIVE="artifacts/${{ steps.release_version.outputs.artifact_base }}-runtime.tar.gz"
+          PRELOADED_ARCHIVE="artifacts/${{ steps.release_version.outputs.artifact_base }}-preloaded.tar.gz"
+          gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Source, bootstrap-download, and preloaded runtime artifacts."
+          gh release upload "$TAG_NAME" "$SOURCE_ARCHIVE" "$RUNTIME_ARCHIVE" "$PRELOADED_ARCHIVE" --clobber

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Current implementation:
 - host-owned shell at `/`
 - embedded sibling `lasso-@serviceadmin` build at `/admin/`
 - tracked repo-owned `services/` definitions for Echo Service and Service Admin
-- prepared local `servicesRoot` copied from tracked service manifests plus a generated Echo Service runner
+- manifest-owned Echo Service archive metadata under `services/echo-service/service.json`
+- prepared local `servicesRoot` copied from the tracked service inventory before runtime startup
 - explicit `src-tauri/` next-step config for a future native wrapper
 
 Current local start command:
@@ -33,7 +34,7 @@ Current local URLs:
 
 ## Current release artifact
 
-This starter repo now has a bounded template-source release artifact.
+This starter repo now has bounded source, bootstrap-download, and preloaded/no-download release artifacts.
 
 Current local commands:
 - `npm test`
@@ -45,14 +46,14 @@ Current pipelines:
   - runs on pushes to `main` and on pull requests
   - installs dependencies and runs `npm test`
 - `Release`
-  - runs on pushes to `main`, version tags, or by manual dispatch
-  - runs tests, verifies the artifact, uploads the packaged files, and creates or updates the rolling `latest` release on `main`
+  - runs on pushes to `main` or by manual dispatch
+  - runs tests, verifies the artifacts, uploads the packaged files, and creates a timestamped `yyyy.m.d-<shortsha>` release from `main`
 
 Current shipped artifact contents are documented in:
 - `docs/release-artifact.md`
 
 Current honest label:
-- this repo ships a runnable desktop-alt host starter plus a starter-template source bundle
+- this repo ships a runnable Tauri app-host starter plus explicit source, bootstrap-download, and preloaded runtime bundles
 
 ## Minimal POC
 

--- a/docs/minimal-poc.md
+++ b/docs/minimal-poc.md
@@ -65,7 +65,7 @@ This bounded POC is now implemented in-repo:
 - `npm start` boots the published `@service-lasso/service-lasso` runtime
 - the host serves its own desktop-alt shell at `/`
 - the host embeds the sibling built `lasso-@serviceadmin` app at `/admin/`
-- the host prepares a local wrapper `servicesRoot` so `lasso-echoservice` is the discovered service under test
+- the host prepares a local `servicesRoot` from the tracked repo `services/` inventory so `echo-service` is discovered from manifest-owned archive metadata
 - `src-tauri/` now contains the explicit next-step config for wrapping the local host URL in a native shell
 
 ## Honest scope limit

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -1,12 +1,22 @@
-# Release artifact
+# Release artifacts
 
-This repo currently ships a bounded **starter-template source artifact**.
+This repo now ships three bounded release artifacts.
 
-That means the release file is intended to give downstream teams a downloadable starting repo shape, not a built production application.
+Each artifact has a different job:
+- source template
+- runnable bootstrap-download bundle
+- runnable preloaded bundle
 
-## What ships
+## Source template
 
-The staged artifact includes the current starter-template source files:
+Artifact:
+- `service-lasso-app-tauri-<version>-source.tar.gz`
+
+Purpose:
+- give downstream teams a downloadable starter repo shape
+- keep tracked `services/` metadata in the template repo itself
+
+What ships:
 - `.gitignore`
 - `.npmrc`
 - `.github/`
@@ -14,18 +24,83 @@ The staged artifact includes the current starter-template source files:
 - `package.json`
 - `package-lock.json`
 - `src/`
+- `src-tauri/`
+- `services/`
 - `docs/`
 - `scripts/`
 - `tests/`
 - generated `release-artifact.json`
 
-## What the artifact proves
+Honest label:
+- **starter-template source artifact**
 
-The artifact proves:
-- the template repo can be packaged repeatably
-- the packaged template contains the documented starter files
-- the staged starter can install the core runtime package and still run `npm start`
-- GitHub Actions can upload the artifact and attach the archive to the rolling `latest` release on `main`
+## Runnable bootstrap-download bundle
+
+Artifact:
+- `service-lasso-app-tauri-<version>-runtime.tar.gz`
+
+Purpose:
+- provide a ready-to-run Tauri-oriented host with the core runtime already installed
+- include bundled Service Admin assets for the host shell
+- keep the canonical repo-owned `services/` inventory inside the artifact
+- prove that Echo Service is acquired from manifest-owned release metadata before use
+
+What ships:
+- `.npmrc`
+- `README.md`
+- `package.json`
+- `package-lock.json`
+- `src/`
+- `src-tauri/`
+- `services/`
+- `docs/`
+- installed `node_modules/`
+- bundled admin assets under `.payload/admin/`
+- generated `release-artifact.json`
+
+How it works:
+- the app repo owns `services/echo-service/service.json`
+- that manifest carries the bounded `artifact` block pointing at the Echo Service release assets
+- on `install`, Service Lasso downloads and unpacks the matching archive from the manifest metadata
+- the app artifact itself does not ship the Echo Service archive preloaded
+
+Honest label:
+- **runnable bootstrap-download bundle**
+
+## Runnable preloaded bundle
+
+Artifact:
+- `service-lasso-app-tauri-<version>-preloaded.tar.gz`
+
+Purpose:
+- provide a ready-to-run Tauri-oriented host with the core runtime already installed
+- include bundled Service Admin assets for the host shell
+- keep the canonical repo-owned `services/` inventory inside the artifact
+- prove that the Echo Service archive is already present before first install/use
+
+What ships:
+- everything in the runnable bootstrap-download bundle
+- preseeded Echo Service archive under:
+  - `.workspace/services/echo-service/.state/artifacts/<releaseTag>/<assetName>`
+
+How it works:
+- the app repo still owns the same canonical `services/echo-service/service.json`
+- the preloaded artifact seeds the matching archive into the runtime-owned service state before first use
+- on `install`, Service Lasso reuses that archive and skips the network fetch
+
+Honest label:
+- **runnable preloaded bundle**
+
+## What the release proves
+
+The release now proves:
+- the repo owns explicit tracked service metadata under `services/`
+- the Tauri-oriented host can be packaged repeatably
+- the runnable artifact can boot Service Lasso and Service Admin without sibling-repo checkout tricks
+- Echo Service acquisition now depends on manifest-owned archive metadata instead of a generated local wrapper
+- bootstrap-download mode installs the service payload before first use
+- preloaded mode installs from an already-shipped archive without a first-run download
+- GitHub Actions can upload the artifacts and attach them to a timestamped `yyyy.m.d-<shortsha>` release on `main`
 
 ## Private package note
 
@@ -35,26 +110,34 @@ This starter depends on the published private core package:
 For local or CI installs from GitHub Packages, provide a token with package read access through:
 - `NODE_AUTH_TOKEN`
 
-The repo `.npmrc` is included in the staged artifact so the starter knows which registry and scope to use.
+The repo `.npmrc` is included in the staged artifacts so the starter knows which registry and scope to use.
 
 ## Commands
 
-Stage the artifact:
+Stage the artifacts:
 
 ```bash
 npm run release:artifact
 ```
 
-Stage and verify the artifact:
+Stage and verify the artifacts:
 
 ```bash
 npm run release:verify
 ```
 
-## Honest current label
+## Release version pattern
 
-This is a:
+Releases from `main` use the project timestamped pattern:
 
-**starter-template source artifact**
+- `yyyy.m.d-<shortsha>`
 
-It is not yet a built native Tauri desktop artifact.
+Example:
+
+- `2026.4.23-abcdef1`
+
+## Current expectation
+
+Any application using Service Lasso should keep a tracked `services/` folder in its repo with the service metadata it intends to manage.
+
+This app-tauri starter now uses that tracked inventory directly for bootstrap-download and preloaded behavior.

--- a/docs/task-list.md
+++ b/docs/task-list.md
@@ -25,7 +25,7 @@ Turn the starter into the smallest real desktop-alt host that:
 4. Serve a host-owned shell page with embedded admin UI and runtime links
    status: done
 
-5. Prepare a local wrapper `servicesRoot` for Echo Service
+5. Prepare a local `servicesRoot` from the tracked service inventory
    status: done
 
 6. Add direct tests for config resolution, host routes, and wrapper materialization

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
-    "test": "node --test tests/**/*.test.js",
+    "test": "node --test --test-concurrency=1 tests/**/*.test.js",
     "release:artifact": "node scripts/release-artifact.mjs",
     "release:verify": "node scripts/release-verify.mjs"
   },

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -1,10 +1,12 @@
 import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
+import { createServer } from "node:http";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
-const CANDIDATE_RELEASE_PATHS = [
+const SOURCE_RELEASE_PATHS = [
   ".gitignore",
   ".npmrc",
   ".github",
@@ -19,16 +21,33 @@ const CANDIDATE_RELEASE_PATHS = [
   "tests",
 ];
 
+const RUNTIME_RELEASE_PATHS = [
+  ".npmrc",
+  "README.md",
+  "package.json",
+  "package-lock.json",
+  "src",
+  "src-tauri",
+  "services",
+  "docs",
+];
+
+const NPM_COMMAND = process.platform === "win32" ? "npm.cmd" : "npm";
+
 export async function readRootPackageJson(repoRoot) {
   return JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
 }
 
 export async function getReleaseVersion(repoRoot) {
+  if (process.env.SERVICE_LASSO_RELEASE_VERSION) {
+    return process.env.SERVICE_LASSO_RELEASE_VERSION;
+  }
+
   const packageJson = await readRootPackageJson(repoRoot);
   return packageJson.version;
 }
 
-export async function getArtifactName(repoRoot, version) {
+export async function getArtifactNameBase(repoRoot, version) {
   const packageJson = await readRootPackageJson(repoRoot);
   const packageSuffix = packageJson.name.split("/").at(-1);
   return `${packageSuffix}-${version}`;
@@ -43,19 +62,27 @@ async function pathExists(targetPath) {
   }
 }
 
-export async function getReleaseFiles(repoRoot) {
-  const releaseFiles = [];
+async function listExistingPaths(repoRoot, candidates) {
+  const existing = [];
 
-  for (const relativePath of CANDIDATE_RELEASE_PATHS) {
+  for (const relativePath of candidates) {
     if (await pathExists(path.join(repoRoot, relativePath))) {
-      releaseFiles.push(relativePath);
+      existing.push(relativePath);
     }
   }
 
-  return releaseFiles;
+  return existing;
 }
 
-async function runCommand(command, args, options = {}) {
+function escapeWindowsCmdArg(value) {
+  if (/^[A-Za-z0-9_./:=@\\-]+$/.test(value)) {
+    return value;
+  }
+
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function runCommand(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: ["ignore", "pipe", "pipe"],
@@ -89,16 +116,6 @@ async function runCommand(command, args, options = {}) {
   });
 }
 
-const NPM_COMMAND = process.platform === "win32" ? "npm.cmd" : "npm";
-
-function escapeWindowsCmdArg(value) {
-  if (/^[A-Za-z0-9_./:=@\\-]+$/.test(value)) {
-    return value;
-  }
-
-  return `"${value.replace(/"/g, '""')}"`;
-}
-
 async function runNpmCommand(args, options = {}) {
   if (process.platform !== "win32") {
     return runCommand(NPM_COMMAND, args, options);
@@ -106,7 +123,6 @@ async function runNpmCommand(args, options = {}) {
 
   const comspec = process.env.ComSpec ?? "cmd.exe";
   const commandLine = [NPM_COMMAND, ...args].map(escapeWindowsCmdArg).join(" ");
-
   return runCommand(comspec, ["/d", "/s", "/c", commandLine], options);
 }
 
@@ -116,30 +132,6 @@ async function copyReleasePath(repoRoot, artifactRoot, relativePath) {
 
   await mkdir(path.dirname(targetPath), { recursive: true });
   await cp(sourcePath, targetPath, { recursive: true });
-}
-
-async function writeReleaseManifest({ repoRoot, artifactRoot, artifactName, version, releaseFiles }) {
-  const packageJson = await readRootPackageJson(repoRoot);
-  const manifest = {
-    artifactName,
-    version,
-    packageName: packageJson.name,
-    artifactKind: "starter-template-source",
-    shippedFiles: releaseFiles,
-    entrypoint: "src/index.js",
-    notes: [
-      "This artifact is a starter-template source bundle.",
-      "It is not yet a built production application artifact.",
-    ],
-  };
-
-  await writeFile(
-    path.join(artifactRoot, "release-artifact.json"),
-    `${JSON.stringify(manifest, null, 2)}\n`,
-    "utf8",
-  );
-
-  return manifest;
 }
 
 async function createReleaseArchive(outputRoot, artifactName) {
@@ -197,39 +189,103 @@ async function installStarterDependencies(stagedRoot, repoRoot) {
   });
 }
 
-async function createVerificationSiblingFixtures(stagedRoot) {
-  const siblingRoot = path.resolve(stagedRoot, "..");
-  const adminDistRoot = path.join(siblingRoot, "lasso-@serviceadmin", "dist");
-  const echoServiceRoot = path.join(siblingRoot, "lasso-echoservice");
+async function writeReleaseManifest({
+  repoRoot,
+  artifactRoot,
+  artifactName,
+  version,
+  artifactKind,
+  shippedFiles,
+  notes,
+}) {
+  const packageJson = await readRootPackageJson(repoRoot);
+  const manifest = {
+    artifactName,
+    version,
+    packageName: packageJson.name,
+    artifactKind,
+    shippedFiles,
+    entrypoint: "src/index.js",
+    startCommand: "npm start",
+    notes,
+  };
 
-  await mkdir(adminDistRoot, { recursive: true });
-  await mkdir(echoServiceRoot, { recursive: true });
-  await writeFile(path.join(adminDistRoot, "index.html"), "<!doctype html><title>serviceadmin</title>", "utf8");
   await writeFile(
-    path.join(echoServiceRoot, "service.json"),
-    `${JSON.stringify(
-      {
-        id: "echo-service",
-        name: "Echo Service",
-        description: "Verification harness service for the tauri starter artifact.",
-        version: "0.0.0",
-        enabled: true,
-        executable: "go",
-        args: ["run", "."],
-        healthcheck: {
-          type: "process",
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    path.join(artifactRoot, "release-artifact.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
     "utf8",
   );
 
+  return manifest;
+}
+
+async function stageSingleArtifact({
+  repoRoot,
+  outputRoot,
+  artifactName,
+  version,
+  artifactKind,
+  relativePaths,
+  notes,
+  installDependencies = false,
+  adminDistRoot = null,
+  preloadedArchive = null,
+}) {
+  const artifactRoot = path.join(outputRoot, artifactName);
+  await rm(artifactRoot, { recursive: true, force: true });
+  await mkdir(outputRoot, { recursive: true });
+
+  for (const relativePath of relativePaths) {
+    await copyReleasePath(repoRoot, artifactRoot, relativePath);
+  }
+
+  if (installDependencies) {
+    await installStarterDependencies(artifactRoot, repoRoot);
+  }
+
+  if (adminDistRoot) {
+    const payloadAdminRoot = path.join(artifactRoot, ".payload", "admin");
+    await mkdir(path.dirname(payloadAdminRoot), { recursive: true });
+    await cp(adminDistRoot, payloadAdminRoot, { recursive: true });
+  }
+
+  if (preloadedArchive) {
+    const { releaseTag, assetName, archivePath } = preloadedArchive;
+    const targetPath = path.join(
+      artifactRoot,
+      ".workspace",
+      "services",
+      "echo-service",
+      ".state",
+      "artifacts",
+      releaseTag,
+      assetName,
+    );
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await cp(archivePath, targetPath, { force: true });
+  }
+
+  const manifest = await writeReleaseManifest({
+    repoRoot,
+    artifactRoot,
+    artifactName,
+    version,
+    artifactKind,
+    shippedFiles: [
+      ...relativePaths,
+      ...(installDependencies ? ["node_modules"] : []),
+      ...(adminDistRoot ? [".payload"] : []),
+      "release-artifact.json",
+    ],
+    notes,
+  });
+  const archivePath = await createReleaseArchive(outputRoot, artifactName);
+
   return {
-    siblingRoot,
-    adminDistRoot,
-    echoServiceRoot,
+    artifactName,
+    artifactRoot,
+    archivePath,
+    manifest,
   };
 }
 
@@ -240,7 +296,6 @@ function sleep(ms) {
 async function reserveLoopbackPort() {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
-
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
       const address = server.address();
@@ -272,6 +327,7 @@ async function waitForJson(url, timeoutMs = 15000) {
       if (response.ok) {
         return await response.json();
       }
+
       lastError = new Error(`unexpected status ${response.status} from ${url}`);
     } catch (error) {
       lastError = error;
@@ -281,6 +337,140 @@ async function waitForJson(url, timeoutMs = 15000) {
   }
 
   throw lastError ?? new Error(`timed out waiting for ${url}`);
+}
+
+async function postJson(url) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: "{}",
+  });
+
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {}
+
+  return {
+    status: response.status,
+    body,
+  };
+}
+
+async function createVerificationAdminDist(rootDir) {
+  const adminDistRoot = path.join(rootDir, "lasso-@serviceadmin", "dist");
+  await mkdir(adminDistRoot, { recursive: true });
+  await writeFile(path.join(adminDistRoot, "index.html"), "<!doctype html><title>serviceadmin</title>", "utf8");
+  await writeFile(path.join(adminDistRoot, "asset.js"), "console.log('serviceadmin asset');", "utf8");
+  return adminDistRoot;
+}
+
+async function createVerificationReleaseFixture(rootDir, assetNameOverride = null) {
+  const fixtureRoot = path.join(rootDir, ".verify-fixture");
+  const workRoot = path.join(fixtureRoot, "work");
+  const archiveRoot = path.join(fixtureRoot, "archives");
+  await mkdir(workRoot, { recursive: true });
+  await mkdir(archiveRoot, { recursive: true });
+  await writeFile(path.join(workRoot, "README.md"), "fixture\n", "utf8");
+
+  let assetName;
+  let archiveType;
+  if (process.platform === "win32") {
+    assetName = assetNameOverride ?? "echo-service-win32.zip";
+    archiveType = "zip";
+    const powershell =
+      process.env.SystemRoot
+        ? path.join(process.env.SystemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+        : "powershell.exe";
+    await runCommand(powershell, [
+      "-NoLogo",
+      "-NoProfile",
+      "-Command",
+      `Compress-Archive -Path '${path.join(workRoot, "*").replace(/'/g, "''")}' -DestinationPath '${path.join(archiveRoot, assetName).replace(/'/g, "''")}' -Force`,
+    ]);
+  } else {
+    assetName = assetNameOverride ?? (process.platform === "darwin" ? "echo-service-darwin.tar.gz" : "echo-service-linux.tar.gz");
+    archiveType = "tar.gz";
+    await runCommand("tar", ["-czf", path.join(archiveRoot, assetName), "-C", workRoot, "."]);
+  }
+
+  const archivePath = path.join(archiveRoot, assetName);
+  return {
+    fixtureRoot,
+    releaseTag: "fixture",
+    assetName,
+    archiveType,
+    archivePath,
+  };
+}
+
+async function startArchiveServer(fixture) {
+  let requestCount = 0;
+  const server = createServer(async (request, response) => {
+    if (request.url !== `/${fixture.assetName}`) {
+      response.statusCode = 404;
+      response.end("not found");
+      return;
+    }
+
+    requestCount += 1;
+    const bytes = await readFile(fixture.archivePath);
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/octet-stream");
+    response.end(bytes);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to start archive fixture server");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/${fixture.assetName}`,
+    getRequestCount() {
+      return requestCount;
+    },
+    async close() {
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+async function createVerificationSourceServicesRoot(stagedRoot, archiveServer, fixture) {
+  const sourceServicesRoot = path.join(stagedRoot, ".verify-source-services");
+  await rm(sourceServicesRoot, { recursive: true, force: true });
+  await cp(path.join(stagedRoot, "services"), sourceServicesRoot, { recursive: true });
+
+  const manifestPath = path.join(sourceServicesRoot, "echo-service", "service.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.version = "fixture";
+  manifest.artifact = {
+    kind: "archive",
+    source: {
+      type: "github-release",
+      repo: "service-lasso/lasso-echoservice",
+      tag: "fixture",
+    },
+    platforms: {
+      [process.platform]: {
+        assetName: fixture.assetName,
+        assetUrl: archiveServer.url,
+        archiveType: fixture.archiveType,
+        command: process.platform === "win32" ? "./echo-service.exe" : "./echo-service",
+        args: [],
+      },
+    },
+  };
+
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return sourceServicesRoot;
 }
 
 async function smokeStarterHost(stagedRoot, env) {
@@ -306,6 +496,7 @@ async function smokeStarterHost(stagedRoot, env) {
       if (settled) {
         return;
       }
+
       settled = true;
       callback();
     };
@@ -339,27 +530,16 @@ async function smokeStarterHost(stagedRoot, env) {
         const hostStatus = await waitForJson(`http://127.0.0.1:${env.SERVICE_LASSO_APP_TAURI_PORT}/api/host-status`);
         const runtimeHealth = await waitForJson(`http://127.0.0.1:${env.SERVICE_LASSO_API_PORT}/api/health`);
 
-        shutdownExpected = true;
-        child.kill("SIGINT");
-        const { code, signal } = await closePromise;
-
-        finish(() => {
-          if (code !== 0 && signal !== "SIGINT" && signal !== "SIGTERM") {
-            reject(
-              new Error(
-                `${process.execPath} ${entrypoint} exited with code ${code} and signal ${signal}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-              ),
-            );
-            return;
-          }
-
+        finish(() =>
           resolve({
+            child,
+            closePromise,
             stdout,
             stderr,
             hostStatus,
             runtimeHealth,
-          });
-        });
+          }),
+        );
       } catch (error) {
         shutdownExpected = true;
         child.kill("SIGTERM");
@@ -369,78 +549,253 @@ async function smokeStarterHost(stagedRoot, env) {
   });
 }
 
-export async function stageReleaseArtifact({ repoRoot, outputRoot = path.join(repoRoot, "artifacts"), version } = {}) {
-  const resolvedVersion = version ?? (await getReleaseVersion(repoRoot));
-  const artifactName = await getArtifactName(repoRoot, resolvedVersion);
-  const artifactRoot = path.join(outputRoot, artifactName);
-  const releaseFiles = await getReleaseFiles(repoRoot);
-
-  await rm(artifactRoot, { recursive: true, force: true });
-  await mkdir(outputRoot, { recursive: true });
-
-  for (const relativePath of releaseFiles) {
-    await copyReleasePath(repoRoot, artifactRoot, relativePath);
-  }
-
-  const manifest = await writeReleaseManifest({
-    repoRoot,
-    artifactRoot,
-    artifactName,
-    version: resolvedVersion,
-    releaseFiles,
-  });
-  const archivePath = await createReleaseArchive(outputRoot, artifactName);
-
-  return {
-    artifactName,
-    artifactRoot,
-    archivePath,
-    manifest,
-  };
+async function shutdownSmokedHost(smoke, signal = "SIGINT") {
+  smoke.child.kill(signal);
+  return smoke.closePromise;
 }
 
-export async function verifyStagedArtifact({ repoRoot, artifactRoot, archivePath, version } = {}) {
-  const resolvedVersion = version ?? (await getReleaseVersion(repoRoot));
-  const artifactName = await getArtifactName(repoRoot, resolvedVersion);
-  const stagedRoot = artifactRoot ?? path.join(repoRoot, "artifacts", artifactName);
-  const stagedArchivePath = archivePath ?? path.join(repoRoot, "artifacts", `${artifactName}.tar.gz`);
-  const releaseFiles = await getReleaseFiles(repoRoot);
+async function verifySourceArtifact({ repoRoot, artifactRoot, archivePath }) {
+  await stat(archivePath);
+  await stat(path.join(artifactRoot, "release-artifact.json"));
 
-  await stat(stagedArchivePath);
-  await stat(path.join(stagedRoot, "release-artifact.json"));
-
-  for (const relativePath of releaseFiles) {
-    await stat(path.join(stagedRoot, relativePath));
-  }
-
-  const packageJson = await readRootPackageJson(repoRoot);
-  const expectedNeedle = packageJson.name.split("/").at(-1);
-  const fixtures = await createVerificationSiblingFixtures(stagedRoot);
+  const adminDistRoot = await createVerificationAdminDist(path.resolve(artifactRoot, ".."));
+  await installStarterDependencies(artifactRoot, repoRoot);
   const hostPort = await reserveLoopbackPort();
   const runtimePort = await reserveLoopbackPort();
-  await installStarterDependencies(stagedRoot, repoRoot);
-  const result = await smokeStarterHost(stagedRoot, {
+  const smoke = await smokeStarterHost(artifactRoot, {
     ...process.env,
     SERVICE_LASSO_APP_TAURI_PORT: hostPort,
     SERVICE_LASSO_API_PORT: runtimePort,
-    SERVICE_LASSO_APP_TAURI_ADMIN_DIST_ROOT: fixtures.adminDistRoot,
-    SERVICE_LASSO_APP_TAURI_ECHO_SERVICE_ROOT: fixtures.echoServiceRoot,
-    SERVICE_LASSO_SERVICES_ROOT: path.join(stagedRoot, ".workspace", "services"),
-    SERVICE_LASSO_WORKSPACE_ROOT: path.join(stagedRoot, ".workspace", "runtime"),
+    SERVICE_LASSO_APP_TAURI_ADMIN_DIST_ROOT: adminDistRoot,
+    SERVICE_LASSO_WORKSPACE_ROOT: path.join(artifactRoot, ".workspace", "runtime"),
   });
 
-  if (!result.stdout.includes(expectedNeedle)) {
-    throw new Error(`staged starter output did not include expected repo marker: ${expectedNeedle}`);
+  try {
+    return {
+      smoke: smoke.stdout,
+      hostStatus: smoke.hostStatus,
+      runtimeHealth: smoke.runtimeHealth,
+    };
+  } finally {
+    await shutdownSmokedHost(smoke, "SIGINT");
   }
+}
+
+async function verifyRuntimeArtifact({ artifactRoot, archivePath }) {
+  await stat(archivePath);
+  await stat(path.join(artifactRoot, "release-artifact.json"));
+  await stat(path.join(artifactRoot, "node_modules"));
+  await stat(path.join(artifactRoot, ".payload", "admin", "index.html"));
+
+  const fixture = await createVerificationReleaseFixture(artifactRoot);
+  const archiveServer = await startArchiveServer(fixture);
+  const sourceServicesRoot = await createVerificationSourceServicesRoot(artifactRoot, archiveServer, fixture);
+  const hostPort = await reserveLoopbackPort();
+  const runtimePort = await reserveLoopbackPort();
+  const smoke = await smokeStarterHost(artifactRoot, {
+    ...process.env,
+    SERVICE_LASSO_APP_TAURI_PORT: hostPort,
+    SERVICE_LASSO_API_PORT: runtimePort,
+    SERVICE_LASSO_APP_TAURI_SOURCE_SERVICES_ROOT: sourceServicesRoot,
+    SERVICE_LASSO_WORKSPACE_ROOT: path.join(artifactRoot, ".workspace", "runtime"),
+  });
+
+  try {
+    const runtimeUrl = `http://127.0.0.1:${runtimePort}`;
+    const install = await postJson(`${runtimeUrl}/api/services/echo-service/install`);
+
+    if (install.status !== 200) {
+      throw new Error(`Install action failed: ${JSON.stringify(install, null, 2)}`);
+    }
+
+    if (archiveServer.getRequestCount() < 1) {
+      throw new Error("Bootstrap-download runtime artifact did not fetch the service archive during install.");
+    }
+
+    const serviceDetail = await waitForJson(`${runtimeUrl}/api/services/echo-service`);
+    return {
+      hostStatus: smoke.hostStatus,
+      runtimeHealth: smoke.runtimeHealth,
+      archiveDownloads: archiveServer.getRequestCount(),
+      installStatus: install.status,
+      lifecycleState: serviceDetail.lifecycleState ?? null,
+    };
+  } finally {
+    await shutdownSmokedHost(smoke, "SIGINT");
+    await archiveServer.close();
+    await rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+async function verifyPreloadedArtifact({ artifactRoot, archivePath }) {
+  await stat(archivePath);
+  await stat(path.join(artifactRoot, "release-artifact.json"));
+  await stat(path.join(artifactRoot, "node_modules"));
+  await stat(path.join(artifactRoot, ".payload", "admin", "index.html"));
+
+  const fixture = await createVerificationReleaseFixture(artifactRoot);
+  const archiveServer = await startArchiveServer(fixture);
+  const sourceServicesRoot = await createVerificationSourceServicesRoot(artifactRoot, archiveServer, fixture);
+  const preloadedArchivePath = path.join(
+    artifactRoot,
+    ".workspace",
+    "services",
+    "echo-service",
+    ".state",
+    "artifacts",
+    "fixture",
+    fixture.assetName,
+  );
+  await mkdir(path.dirname(preloadedArchivePath), { recursive: true });
+  await cp(fixture.archivePath, preloadedArchivePath, { force: true });
+
+  const hostPort = await reserveLoopbackPort();
+  const runtimePort = await reserveLoopbackPort();
+  const smoke = await smokeStarterHost(artifactRoot, {
+    ...process.env,
+    SERVICE_LASSO_APP_TAURI_PORT: hostPort,
+    SERVICE_LASSO_API_PORT: runtimePort,
+    SERVICE_LASSO_APP_TAURI_SOURCE_SERVICES_ROOT: sourceServicesRoot,
+    SERVICE_LASSO_WORKSPACE_ROOT: path.join(artifactRoot, ".workspace", "runtime"),
+  });
+
+  try {
+    const runtimeUrl = `http://127.0.0.1:${runtimePort}`;
+    const install = await postJson(`${runtimeUrl}/api/services/echo-service/install`);
+
+    if (install.status !== 200) {
+      throw new Error(`Install action failed: ${JSON.stringify(install, null, 2)}`);
+    }
+
+    if (archiveServer.getRequestCount() !== 0) {
+      throw new Error("Preloaded runtime artifact should not fetch the service archive during install.");
+    }
+
+    const serviceDetail = await waitForJson(`${runtimeUrl}/api/services/echo-service`);
+    return {
+      hostStatus: smoke.hostStatus,
+      runtimeHealth: smoke.runtimeHealth,
+      archiveDownloads: archiveServer.getRequestCount(),
+      installStatus: install.status,
+      lifecycleState: serviceDetail.lifecycleState ?? null,
+    };
+  } finally {
+    await shutdownSmokedHost(smoke, "SIGINT");
+    await archiveServer.close();
+    await rm(fixture.fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+export async function stageReleaseArtifacts({ repoRoot, outputRoot = path.join(repoRoot, "artifacts"), version, sourceAdminDistRoot } = {}) {
+  const resolvedVersion = version ?? (await getReleaseVersion(repoRoot));
+  const baseName = await getArtifactNameBase(repoRoot, resolvedVersion);
+  const sourceFiles = await listExistingPaths(repoRoot, SOURCE_RELEASE_PATHS);
+  const runtimeFiles = await listExistingPaths(repoRoot, RUNTIME_RELEASE_PATHS);
+  const resolvedAdminDistRoot =
+    sourceAdminDistRoot ??
+    process.env.SERVICE_LASSO_APP_TAURI_ADMIN_DIST_ROOT ??
+    (existsSync(path.resolve(repoRoot, "..", "lasso-@serviceadmin", "dist"))
+      ? path.resolve(repoRoot, "..", "lasso-@serviceadmin", "dist")
+      : null);
+
+  const source = await stageSingleArtifact({
+    repoRoot,
+    outputRoot,
+    artifactName: `${baseName}-source`,
+    version: resolvedVersion,
+    artifactKind: "starter-template-source",
+    relativePaths: sourceFiles,
+    notes: [
+      "This artifact is the source template for the app-tauri starter.",
+      "It keeps the tracked services/ inventory but does not include installed dependencies or bundled runtime payloads.",
+    ],
+  });
+
+  const runtime = await stageSingleArtifact({
+    repoRoot,
+    outputRoot,
+    artifactName: `${baseName}-runtime`,
+    version: resolvedVersion,
+    artifactKind: "runnable-bootstrap-download",
+    relativePaths: runtimeFiles,
+    notes: [
+      "This artifact is ready to run with installed dependencies and bundled Service Admin assets.",
+      "It keeps the canonical services/ inventory and installs the Echo Service archive from manifest-owned metadata before use.",
+    ],
+    installDependencies: true,
+    adminDistRoot: resolvedAdminDistRoot,
+  });
+
+  const echoManifest = JSON.parse(await readFile(path.join(repoRoot, "services", "echo-service", "service.json"), "utf8"));
+  const echoPlatform = echoManifest.artifact?.platforms?.[process.platform] ?? echoManifest.artifact?.platforms?.default;
+  const preloadedFixture = await createVerificationReleaseFixture(outputRoot, echoPlatform?.assetName ?? null);
+  const preloaded = await stageSingleArtifact({
+    repoRoot,
+    outputRoot,
+    artifactName: `${baseName}-preloaded`,
+    version: resolvedVersion,
+    artifactKind: "runnable-preloaded",
+    relativePaths: runtimeFiles,
+    notes: [
+      "This artifact is ready to run with installed dependencies, bundled Service Admin assets, and a preseeded Echo Service archive.",
+      "It keeps the canonical services/ inventory and proves no first-run service download is required.",
+    ],
+    installDependencies: true,
+    adminDistRoot: resolvedAdminDistRoot,
+    preloadedArchive: {
+      releaseTag: echoManifest.artifact?.source?.tag ?? preloadedFixture.releaseTag,
+      assetName: preloadedFixture.assetName,
+      archivePath: preloadedFixture.archivePath,
+    },
+  });
+  await rm(preloadedFixture.fixtureRoot, { recursive: true, force: true });
 
   return {
-    artifactName,
-    stagedRoot,
-    stagedArchivePath,
-    smoke: result.stdout,
+    version: resolvedVersion,
+    baseName,
+    artifacts: {
+      source,
+      runtime,
+      preloaded,
+    },
   };
 }
 
-export async function createTemporaryOutputRoot(prefix = "service-lasso-template-release-") {
+export async function verifyStagedArtifacts({ repoRoot, staged } = {}) {
+  const release = staged ?? (await stageReleaseArtifacts({ repoRoot }));
+  const sourceVerified = await verifySourceArtifact({
+    repoRoot,
+    artifactRoot: release.artifacts.source.artifactRoot,
+    archivePath: release.artifacts.source.archivePath,
+  });
+  const runtimeVerified = await verifyRuntimeArtifact({
+    artifactRoot: release.artifacts.runtime.artifactRoot,
+    archivePath: release.artifacts.runtime.archivePath,
+  });
+  const preloadedVerified = await verifyPreloadedArtifact({
+    artifactRoot: release.artifacts.preloaded.artifactRoot,
+    archivePath: release.artifacts.preloaded.archivePath,
+  });
+
+  return {
+    baseName: release.baseName,
+    artifacts: {
+      source: {
+        ...release.artifacts.source,
+        verification: sourceVerified,
+      },
+      runtime: {
+        ...release.artifacts.runtime,
+        verification: runtimeVerified,
+      },
+      preloaded: {
+        ...release.artifacts.preloaded,
+        verification: preloadedVerified,
+      },
+    },
+  };
+}
+
+export async function createTemporaryOutputRoot(prefix = "service-lasso-app-tauri-release-") {
   return mkdtemp(path.join(os.tmpdir(), prefix));
 }

--- a/scripts/release-artifact.mjs
+++ b/scripts/release-artifact.mjs
@@ -1,11 +1,17 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { stageReleaseArtifact } from "./release-artifact-lib.mjs";
+import { stageReleaseArtifacts } from "./release-artifact-lib.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const result = await stageReleaseArtifact({ repoRoot });
+const result = await stageReleaseArtifacts({ repoRoot });
 
-console.log("[service-lasso starter] staged release artifact");
-console.log(`- artifact: ${result.artifactName}`);
-console.log(`- folder: ${result.artifactRoot}`);
-console.log(`- archive: ${result.archivePath}`);
+console.log("[service-lasso starter] staged release artifacts");
+console.log(`- source artifact: ${result.artifacts.source.artifactName}`);
+console.log(`- source folder: ${result.artifacts.source.artifactRoot}`);
+console.log(`- source archive: ${result.artifacts.source.archivePath}`);
+console.log(`- runtime artifact: ${result.artifacts.runtime.artifactName}`);
+console.log(`- runtime folder: ${result.artifacts.runtime.artifactRoot}`);
+console.log(`- runtime archive: ${result.artifacts.runtime.archivePath}`);
+console.log(`- preloaded artifact: ${result.artifacts.preloaded.artifactName}`);
+console.log(`- preloaded folder: ${result.artifacts.preloaded.artifactRoot}`);
+console.log(`- preloaded archive: ${result.artifacts.preloaded.archivePath}`);

--- a/scripts/release-verify.mjs
+++ b/scripts/release-verify.mjs
@@ -1,16 +1,18 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { stageReleaseArtifact, verifyStagedArtifact } from "./release-artifact-lib.mjs";
+import { stageReleaseArtifacts, verifyStagedArtifacts } from "./release-artifact-lib.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const staged = await stageReleaseArtifact({ repoRoot });
-const verified = await verifyStagedArtifact({
+const staged = await stageReleaseArtifacts({ repoRoot });
+const verified = await verifyStagedArtifacts({
   repoRoot,
-  artifactRoot: staged.artifactRoot,
-  archivePath: staged.archivePath,
+  staged,
 });
 
-console.log("[service-lasso starter] verified release artifact");
-console.log(`- artifact: ${verified.artifactName}`);
-console.log(`- folder: ${verified.stagedRoot}`);
-console.log(`- archive: ${verified.stagedArchivePath}`);
+console.log("[service-lasso starter] verified release artifacts");
+console.log(`- source artifact: ${verified.artifacts.source.artifactName}`);
+console.log(`- source archive: ${verified.artifacts.source.archivePath}`);
+console.log(`- runtime artifact: ${verified.artifacts.runtime.artifactName}`);
+console.log(`- runtime archive: ${verified.artifacts.runtime.archivePath}`);
+console.log(`- preloaded artifact: ${verified.artifacts.preloaded.artifactName}`);
+console.log(`- preloaded archive: ${verified.artifacts.preloaded.archivePath}`);

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -1,11 +1,41 @@
 {
   "id": "echo-service",
   "name": "Echo Service",
-  "description": "Release-backed Echo Service harness for the app-tauri starter.",
-  "version": "0.3.0",
+  "description": "Release-backed Echo Service harness for the app-tauri starter bootstrap-download flow.",
+  "version": "2026.4.20-a417abd",
   "enabled": true,
-  "executable": "node",
-  "args": ["./run-echo-service.mjs"],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-echoservice",
+      "tag": "2026.4.20-a417abd",
+      "serviceManifestAssetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/service.json"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "echo-service-win32.zip",
+        "assetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/echo-service-win32.zip",
+        "archiveType": "zip",
+        "command": "./echo-service.exe",
+        "args": []
+      },
+      "linux": {
+        "assetName": "echo-service-linux.tar.gz",
+        "assetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/echo-service-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./echo-service",
+        "args": []
+      },
+      "darwin": {
+        "assetName": "echo-service-darwin.tar.gz",
+        "assetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/echo-service-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./echo-service",
+        "args": []
+      }
+    }
+  },
   "env": {
     "ECHO_MESSAGE": "hello from service-lasso-app-tauri",
     "ECHO_PORT": "4010",

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { access } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -12,7 +13,9 @@ export function resolveTauriConfig(options = {}) {
   const adminDistRoot =
     options.adminDistRoot ??
     process.env.SERVICE_LASSO_APP_TAURI_ADMIN_DIST_ROOT ??
-    path.join(siblingRoot, "lasso-@serviceadmin", "dist");
+    (existsSync(path.join(rootDir, ".payload", "admin"))
+      ? path.join(rootDir, ".payload", "admin")
+      : path.join(siblingRoot, "lasso-@serviceadmin", "dist"));
   const workspaceBaseRoot =
     options.workspaceBaseRoot ??
     process.env.SERVICE_LASSO_APP_TAURI_WORKSPACE_BASE_ROOT ??
@@ -29,10 +32,6 @@ export function resolveTauriConfig(options = {}) {
     options.sourceServicesRoot ??
     process.env.SERVICE_LASSO_APP_TAURI_SOURCE_SERVICES_ROOT ??
     path.join(rootDir, "services");
-  const echoServiceRepoRoot =
-    options.echoServiceRepoRoot ??
-    process.env.SERVICE_LASSO_APP_TAURI_ECHO_SERVICE_REPO_ROOT ??
-    path.join(siblingRoot, "lasso-echoservice");
 
   return {
     repoRoot: rootDir,
@@ -47,7 +46,6 @@ export function resolveTauriConfig(options = {}) {
     workspaceRoot,
     servicesRoot,
     sourceServicesRoot,
-    echoServiceRepoRoot,
     tauriConfigPath: path.join(rootDir, "src-tauri", "tauri.conf.json"),
   };
 }
@@ -55,7 +53,6 @@ export function resolveTauriConfig(options = {}) {
 export async function validateTauriConfig(config) {
   await access(path.join(config.sourceServicesRoot, "echo-service", "service.json"));
   await access(path.join(config.sourceServicesRoot, "service-admin", "service.json"));
-  await access(path.join(config.echoServiceRepoRoot, "service.json"));
   await access(path.join(config.adminDistRoot, "index.html"));
   return config;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -152,7 +152,7 @@ function createShellHtml(config) {
         <span class="eyebrow">Desktop Alt Shell</span>
         <h1>Tauri-ready shell for Service Lasso</h1>
         <p>
-          This bounded host keeps the runtime and admin wiring executable today, while the future native Tauri wrapper simply needs to point its window at this local shell.
+          This bounded host keeps the runtime and admin wiring executable today, while the future native Tauri wrapper simply needs to point its window at this local shell and the tracked service inventory.
         </p>
         <div class="card">
           <span class="label">Runtime API</span>
@@ -219,14 +219,13 @@ export function createHostStatus(config) {
     servicesRoot: config.servicesRoot,
     sourceServicesRoot: config.sourceServicesRoot,
     workspaceRoot: config.workspaceRoot,
-    echoServiceRepoRoot: config.echoServiceRepoRoot,
     adminDistRoot: config.adminDistRoot,
     tauriConfigPath: config.tauriConfigPath,
     notes: [
       "Desktop-alt shell is served at /.",
       "Service Admin is mounted from the sibling build under /admin/.",
       "Tracked services/ definitions are copied into the prepared servicesRoot before runtime startup.",
-      "A local Echo Service runner is generated into the prepared servicesRoot.",
+      "Echo Service archive metadata now lives in services/echo-service/service.json.",
       "The next native Tauri wrapper should open this local host URL inside the desktop shell.",
     ],
   };

--- a/src/services-root.js
+++ b/src/services-root.js
@@ -1,43 +1,13 @@
 import path from "node:path";
-import { cp, mkdir, writeFile } from "node:fs/promises";
+import { cp } from "node:fs/promises";
 
 export async function prepareStarterServicesRoot(config) {
-  const wrapperServiceRoot = path.join(config.servicesRoot, "echo-service");
-  const wrapperEntrypointPath = path.join(wrapperServiceRoot, "run-echo-service.mjs");
-
-  const wrapperScript = [
-    'import { spawn } from "node:child_process";',
-    "",
-    `const echoServiceRoot = ${JSON.stringify(config.echoServiceRepoRoot)};`,
-    'const child = spawn("go", ["run", "."], {',
-    "  cwd: echoServiceRoot,",
-    "  env: process.env,",
-    '  stdio: "inherit",',
-    "});",
-    "",
-    'for (const signal of ["SIGINT", "SIGTERM"]) {',
-    "  process.on(signal, () => {",
-    "    child.kill(signal);",
-    "  });",
-    "}",
-    "",
-    'child.on("exit", (code, signal) => {',
-    "  if (signal) {",
-    "    process.exit(1);",
-    "    return;",
-    "  }",
-    "  process.exit(code ?? 0);",
-    "});",
-    "",
-  ].join("\n");
   await cp(config.sourceServicesRoot, config.servicesRoot, { recursive: true, force: true });
-  await mkdir(wrapperServiceRoot, { recursive: true });
-  await writeFile(wrapperEntrypointPath, `${wrapperScript}\n`, "utf8");
 
   return {
     servicesRoot: config.servicesRoot,
-    echoServiceRoot: wrapperServiceRoot,
+    echoServiceRoot: path.join(config.servicesRoot, "echo-service"),
     serviceAdminRoot: path.join(config.servicesRoot, "service-admin"),
-    wrapperEntrypointPath,
+    echoServiceManifestPath: path.join(config.servicesRoot, "echo-service", "service.json"),
   };
 }

--- a/tests/host.test.js
+++ b/tests/host.test.js
@@ -11,24 +11,24 @@ async function createFixtureRoots() {
   const root = await mkdtemp(path.join(tmpdir(), "service-lasso-app-tauri-"));
   const siblingRoot = path.join(root, "siblings");
   const adminDistRoot = path.join(siblingRoot, "lasso-@serviceadmin", "dist");
-  const echoServiceRepoRoot = path.join(siblingRoot, "lasso-echoservice");
   const sourceServicesRoot = path.join(root, "service-lasso-app-tauri", "services");
 
   await mkdir(adminDistRoot, { recursive: true });
-  await mkdir(echoServiceRepoRoot, { recursive: true });
   await mkdir(path.join(sourceServicesRoot, "echo-service"), { recursive: true });
   await mkdir(path.join(sourceServicesRoot, "service-admin"), { recursive: true });
   await writeFile(path.join(adminDistRoot, "index.html"), "<!doctype html><title>admin</title>", "utf8");
   await writeFile(path.join(adminDistRoot, "asset.js"), "console.log('admin asset');", "utf8");
-  await writeFile(path.join(echoServiceRepoRoot, "service.json"), "{\n  \"id\": \"echo-service\"\n}\n", "utf8");
-  await writeFile(path.join(sourceServicesRoot, "echo-service", "service.json"), "{\n  \"id\": \"echo-service\"\n}\n", "utf8");
+  await writeFile(
+    path.join(sourceServicesRoot, "echo-service", "service.json"),
+    "{\n  \"id\": \"echo-service\",\n  \"artifact\": {\n    \"kind\": \"archive\"\n  }\n}\n",
+    "utf8",
+  );
   await writeFile(path.join(sourceServicesRoot, "service-admin", "service.json"), "{\n  \"id\": \"service-admin\"\n}\n", "utf8");
 
   return {
     root,
     siblingRoot,
     adminDistRoot,
-    echoServiceRepoRoot,
     sourceServicesRoot,
   };
 }
@@ -48,7 +48,6 @@ test("tauri config resolves deterministic sibling repo paths", async () => {
     assert.equal(config.runtimeUrl, "http://127.0.0.1:18196");
     assert.equal(config.adminDistRoot, fixture.adminDistRoot);
     assert.equal(config.sourceServicesRoot, fixture.sourceServicesRoot);
-    assert.equal(config.echoServiceRepoRoot, fixture.echoServiceRepoRoot);
     assert.match(config.tauriConfigPath, /src-tauri[\\/]tauri\.conf\.json$/);
 
     await assert.doesNotReject(() => validateTauriConfig(config));
@@ -72,7 +71,6 @@ test("desktop-alt host serves shell, host status, and mounted admin assets", asy
     const status = createHostStatus(config);
     assert.equal(status.app, "@service-lasso/service-lasso-app-tauri");
     assert.equal(status.sourceServicesRoot, fixture.sourceServicesRoot);
-    assert.equal(status.echoServiceRepoRoot, fixture.echoServiceRepoRoot);
 
     const server = createTauriHostServer(config);
     server.listen(0, "127.0.0.1");

--- a/tests/release-artifact.test.js
+++ b/tests/release-artifact.test.js
@@ -6,34 +6,62 @@ import { rm } from "node:fs/promises";
 import {
   createTemporaryOutputRoot,
   readRootPackageJson,
-  stageReleaseArtifact,
-  verifyStagedArtifact,
+  stageReleaseArtifacts,
+  verifyStagedArtifacts,
 } from "../scripts/release-artifact-lib.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-test("starter release artifact can be staged and verified", async () => {
+test("starter release artifacts can be staged and verified", async () => {
   const outputRoot = await createTemporaryOutputRoot();
 
   try {
     const packageJson = await readRootPackageJson(repoRoot);
     const packageSuffix = packageJson.name.split("/").at(-1);
-    const staged = await stageReleaseArtifact({
+    const staged = await stageReleaseArtifacts({
       repoRoot,
       outputRoot,
     });
 
-    assert.match(staged.artifactName, new RegExp(`^${packageSuffix}-\\d+\\.\\d+\\.\\d+$`));
-    assert.equal(staged.manifest.artifactKind, "starter-template-source");
+    assert.match(staged.baseName, new RegExp(`^${packageSuffix}-\\d+\\.\\d+\\.\\d+$`));
+    assert.equal(staged.artifacts.source.manifest.artifactKind, "starter-template-source");
+    assert.equal(staged.artifacts.runtime.manifest.artifactKind, "runnable-bootstrap-download");
+    assert.equal(staged.artifacts.preloaded.manifest.artifactKind, "runnable-preloaded");
 
-    const verified = await verifyStagedArtifact({
+    const verified = await verifyStagedArtifacts({
       repoRoot,
-      artifactRoot: staged.artifactRoot,
-      archivePath: staged.archivePath,
+      staged,
     });
 
-    assert.equal(verified.artifactName, staged.artifactName);
+    assert.equal(verified.baseName, staged.baseName);
+    assert.ok(verified.artifacts.runtime.verification.archiveDownloads >= 1);
+    assert.equal(verified.artifacts.preloaded.verification.archiveDownloads, 0);
   } finally {
+    await rm(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test("starter release artifacts respect SERVICE_LASSO_RELEASE_VERSION when provided", async () => {
+  const outputRoot = await createTemporaryOutputRoot();
+  const previousVersion = process.env.SERVICE_LASSO_RELEASE_VERSION;
+  process.env.SERVICE_LASSO_RELEASE_VERSION = "2026.4.23-abcdef1";
+
+  try {
+    const packageJson = await readRootPackageJson(repoRoot);
+    const packageSuffix = packageJson.name.split("/").at(-1);
+    const staged = await stageReleaseArtifacts({
+      repoRoot,
+      outputRoot,
+    });
+
+    assert.equal(staged.baseName, `${packageSuffix}-2026.4.23-abcdef1`);
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.SERVICE_LASSO_RELEASE_VERSION;
+    } else {
+      process.env.SERVICE_LASSO_RELEASE_VERSION = previousVersion;
+    }
+
     await rm(outputRoot, { recursive: true, force: true });
   }
 });

--- a/tests/services-root.test.js
+++ b/tests/services-root.test.js
@@ -5,18 +5,16 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { prepareStarterServicesRoot } from "../src/services-root.js";
 
-test("desktop-alt starter servicesRoot is prepared with an echo-service wrapper manifest", async () => {
+test("desktop-alt starter servicesRoot is prepared from tracked service manifests without a generated wrapper", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "service-lasso-app-tauri-services-"));
-  const echoServiceRepoRoot = path.join(root, "lasso-echoservice");
   const sourceServicesRoot = path.join(root, "services-template");
   const servicesRoot = path.join(root, ".workspace", "services");
 
   try {
-    await mkdir(echoServiceRepoRoot, { recursive: true });
     await mkdir(path.join(sourceServicesRoot, "echo-service"), { recursive: true });
     await mkdir(path.join(sourceServicesRoot, "service-admin"), { recursive: true });
     await writeFile(
-      path.join(echoServiceRepoRoot, "service.json"),
+      path.join(sourceServicesRoot, "echo-service", "service.json"),
       `${JSON.stringify(
         {
           id: "echo-service",
@@ -24,8 +22,23 @@ test("desktop-alt starter servicesRoot is prepared with an echo-service wrapper 
           description: "Harness",
           version: "0.0.0",
           enabled: true,
-          executable: "go",
-          args: ["run", "."],
+          artifact: {
+            kind: "archive",
+            source: {
+              type: "github-release",
+              repo: "service-lasso/lasso-echoservice",
+              tag: "fixture",
+            },
+            platforms: {
+              [process.platform]: {
+                assetName: "echo-service.zip",
+                assetUrl: "http://127.0.0.1:9999/echo-service.zip",
+                archiveType: process.platform === "win32" ? "zip" : "tar.gz",
+                command: process.platform === "win32" ? "./echo-service.exe" : "./echo-service",
+                args: [],
+              },
+            },
+          },
           healthcheck: {
             type: "process",
           },
@@ -36,11 +49,6 @@ test("desktop-alt starter servicesRoot is prepared with an echo-service wrapper 
       "utf8",
     );
     await writeFile(
-      path.join(sourceServicesRoot, "echo-service", "service.json"),
-      "{\n  \"id\": \"echo-service\",\n  \"executable\": \"node\",\n  \"args\": [\"./run-echo-service.mjs\"]\n}\n",
-      "utf8",
-    );
-    await writeFile(
       path.join(sourceServicesRoot, "service-admin", "service.json"),
       "{\n  \"id\": \"service-admin\",\n  \"enabled\": false\n}\n",
       "utf8",
@@ -48,21 +56,17 @@ test("desktop-alt starter servicesRoot is prepared with an echo-service wrapper 
 
     const prepared = await prepareStarterServicesRoot({
       sourceServicesRoot,
-      echoServiceRepoRoot,
       servicesRoot,
     });
 
     assert.equal(prepared.echoServiceRoot, path.join(servicesRoot, "echo-service"));
     assert.equal(prepared.serviceAdminRoot, path.join(servicesRoot, "service-admin"));
-    const wrapperManifest = JSON.parse(await readFile(path.join(servicesRoot, "echo-service", "service.json"), "utf8"));
-    assert.equal(wrapperManifest.id, "echo-service");
-    assert.equal(wrapperManifest.executable, "node");
-    assert.deepEqual(wrapperManifest.args, ["./run-echo-service.mjs"]);
+    const manifest = JSON.parse(await readFile(path.join(servicesRoot, "echo-service", "service.json"), "utf8"));
+    assert.equal(manifest.id, "echo-service");
+    assert.equal(manifest.artifact.source.repo, "service-lasso/lasso-echoservice");
+    assert.equal(prepared.echoServiceManifestPath, path.join(servicesRoot, "echo-service", "service.json"));
     const adminManifest = JSON.parse(await readFile(path.join(servicesRoot, "service-admin", "service.json"), "utf8"));
     assert.equal(adminManifest.id, "service-admin");
-    const wrapperEntrypoint = await readFile(prepared.wrapperEntrypointPath, "utf8");
-    assert.match(wrapperEntrypoint, /spawn\("go", \["run", "\."\]/);
-    assert.match(wrapperEntrypoint, new RegExp(JSON.stringify(echoServiceRepoRoot).slice(1, -1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- move echo-service archive acquisition metadata into service.json
- stage source, runtime, and preloaded artifacts with timestamped releases
- remove generated echo wrapper behavior from the tracked services inventory

## Testing
- npm test
- SERVICE_LASSO_RELEASE_VERSION=2026.4.23-abcdef1 npm run release:verify
- git diff --check
