### PR TITLE
ISS-075: Isolate core package staging

### DIFF
--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -141,7 +141,7 @@ async function createReleaseArchive(outputRoot, artifactName) {
   return archivePath;
 }
 
-async function getLocalCorePackageArchive(repoRoot) {
+async function getLocalCorePackageArchive(repoRoot, stagedRoot) {
   const candidateRoots = [
     process.env.SERVICE_LASSO_CORE_REPO_ROOT,
     path.join(repoRoot, ".service-lasso-core"),
@@ -155,25 +155,35 @@ async function getLocalCorePackageArchive(repoRoot) {
 
     const corePackageJson = JSON.parse(await readFile(path.join(coreRepoRoot, "package.json"), "utf8"));
     const version = corePackageJson.version;
-    const artifactRoot = path.join(coreRepoRoot, "artifacts", "npm", `service-lasso-package-${version}`);
+    const isolatedOutputRoot = await mkdtemp(path.join(os.tmpdir(), "service-lasso-core-package-"));
+    const artifactRoot = path.join(isolatedOutputRoot, `service-lasso-package-${version}`);
     const archivePath = path.join(artifactRoot, `service-lasso-service-lasso-${version}.tgz`);
 
-    if (!(await pathExists(archivePath))) {
+    try {
       await runNpmCommand(["run", "package:stage"], {
         cwd: coreRepoRoot,
-        env: process.env,
+        env: {
+          ...process.env,
+          SERVICE_LASSO_RELEASE_VERSION: version,
+          SERVICE_LASSO_PACKAGE_OUTPUT_ROOT: isolatedOutputRoot,
+        },
       });
-    }
 
-    await stat(archivePath);
-    return archivePath;
+      await stat(archivePath);
+      const localArchivePath = path.join(stagedRoot, ".service-lasso-core-package", path.basename(archivePath));
+      await mkdir(path.dirname(localArchivePath), { recursive: true });
+      await cp(archivePath, localArchivePath, { force: true });
+      return `./${path.relative(stagedRoot, localArchivePath).split(path.sep).join("/")}`;
+    } finally {
+      await rm(isolatedOutputRoot, { recursive: true, force: true });
+    }
   }
 
   return null;
 }
 
 async function installStarterDependencies(stagedRoot, repoRoot) {
-  const localCorePackageArchive = await getLocalCorePackageArchive(repoRoot);
+  const localCorePackageArchive = await getLocalCorePackageArchive(repoRoot, stagedRoot);
 
   if (localCorePackageArchive) {
     await runNpmCommand(["install", localCorePackageArchive], {


### PR DESCRIPTION
## Summary

- Stages the local core package into an isolated temp output root during release verification.
- Copies the staged core `.tgz` into the app artifact before `npm install` so concurrent reference-app validations cannot delete each other's package archive.
- Uses a relative package path for Windows-safe npm installs.

## Verification

- Parallel `npm test` passed across all five reference app repos.

Part of service-lasso/service-lasso#75.
