### PR TITLE
Use public npmjs for Service Lasso package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
 
     steps:
       - name: Check out repo
@@ -22,10 +21,10 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://npm.pkg.github.com
-          scope: "@service-lasso"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm test
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: read
 
     steps:
       - name: Check out repo
@@ -32,18 +31,17 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://npm.pkg.github.com
-          scope: "@service-lasso"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm test
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Verify release artifact
         run: npm run release:verify
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
           SERVICE_LASSO_RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
 
       - name: Upload staged source artifact folder

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@service-lasso:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -103,17 +103,14 @@ The release now proves:
 - preloaded mode installs from an already-shipped archive without a first-run download
 - GitHub Actions can upload the artifacts and attach them to a timestamped `yyyy.m.d-<shortsha>` release on `main`
 
-## Private package note
+## Public package note
 
-This starter depends on the published private core package:
+This starter depends on the public npm core package:
 - `@service-lasso/service-lasso@latest`
 
 The `latest` dist-tag is intentional so starter artifacts consume the current manifest-owned install/acquire behavior published by the core repo.
 
-For local or CI installs from GitHub Packages, provide a token with package read access through:
-- `NODE_AUTH_TOKEN`
-
-The repo `.npmrc` is included in the staged artifacts so the starter knows which registry and scope to use.
+Local and CI installs resolve it from `https://registry.npmjs.org` without GitHub Packages auth.
 
 ## Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,102 @@
     "": {
       "name": "@service-lasso/service-lasso-app-tauri",
       "version": "0.1.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@service-lasso/service-lasso": "latest"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@service-lasso/service-lasso": {
+      "version": "2026.4.24-a663bb0",
+      "resolved": "https://registry.npmjs.org/@service-lasso/service-lasso/-/service-lasso-2026.4.24-a663bb0.tgz",
+      "integrity": "sha512-hJXvbQAzwnHg2qnHrGnzAzQg3j6mgzTrHHrBfXx6Y3FERrwxO8lgmeU3YZRlRRFqQknkMyqEi7CEvuZO4ISHug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "tar": "^7.5.2"
+      },
+      "bin": {
+        "service-lasso": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Migrates the Tauri reference app from GitHub Packages npm auth to public npmjs for `@service-lasso/service-lasso`.

## Changes

- Removes `.npmrc` GitHub Packages scope config.
- Uses `https://registry.npmjs.org` in CI/release workflows.
- Removes package-read permission and npm `NODE_AUTH_TOKEN` install wiring.
- Adds explicit `npm ci` steps.
- Regenerates `package-lock.json` with `@service-lasso/service-lasso@2026.4.24-a663bb0` from npmjs.
- Updates release docs for the public package path.

## Verification

- `npm test`
- `npm run release:verify`
- `git diff --check`
